### PR TITLE
Fftw bugfix

### DIFF
--- a/silx/math/fft/basefft.py
+++ b/silx/math/fft/basefft.py
@@ -61,7 +61,6 @@ class BaseFFT(object):
         self.__set_dtypes()
         self.__calc_shape()
 
-
     def __get_args(self, **kwargs):
         expected_args = {
             "shape": None,
@@ -96,7 +95,6 @@ class BaseFFT(object):
                 self.dtype_in
             )
         self.dtype_out = dtypes_mapping[self.dtype_in]
-
 
     def __calc_shape(self):
         # TODO allow for C2C even for real input data (?)
@@ -146,4 +144,3 @@ class BaseFFT(object):
 
     def ifft(self, array, **kwargs):
         raise ValueError("This should be implemented by back-end FFT")
-

--- a/silx/math/fft/fftw.py
+++ b/silx/math/fft/fftw.py
@@ -87,7 +87,6 @@ class FFTW(BaseFFT):
             "data_out": self.data_out,
         }
 
-
     def set_fftw_flags(self):
         self.fftw_flags = ('FFTW_MEASURE', ) # TODO
         self.fftw_planning_timelimit = None # TODO
@@ -102,10 +101,8 @@ class FFTW(BaseFFT):
             )
         self.fftw_norm_mode = self.fftw_norm_modes[self.normalize]
 
-
     def _allocate(self, shape, dtype):
         return pyfftw.zeros_aligned(shape, dtype=dtype)
-
 
     def check_array(self, array, shape, dtype, copy=True):
         if array.shape != shape:
@@ -116,7 +113,6 @@ class FFTW(BaseFFT):
             raise ValueError("Invalid data type: expected %s, got %s" %
                 (dtype, array.dtype)
             )
-
 
     def set_data(self, self_array, array, shape, dtype, copy=True, name=None):
         """
@@ -153,7 +149,6 @@ class FFTW(BaseFFT):
                 arr_to_use = array
         return arr_to_use
 
-
     def compute_forward_plan(self):
         self.plan_forward = pyfftw.FFTW(
             self.data_in,
@@ -168,7 +163,6 @@ class FFTW(BaseFFT):
             normalise_idft=self.fftw_norm_mode["normalize"],
         )
 
-
     def compute_inverse_plan(self):
         self.plan_inverse = pyfftw.FFTW(
             self.data_out,
@@ -182,7 +176,6 @@ class FFTW(BaseFFT):
             ortho=self.fftw_norm_mode["ortho"],
             normalise_idft=self.fftw_norm_mode["normalize"],
         )
-
 
     def fft(self, array, output=None):
         """
@@ -206,7 +199,6 @@ class FFTW(BaseFFT):
         self.plan_forward.update_arrays(self.refs["data_in"], self.refs["data_out"])
         return data_out
 
-
     def ifft(self, array, output=None):
         """
         Perform a (inverse) Fast Fourier Transform.
@@ -229,5 +221,3 @@ class FFTW(BaseFFT):
         # ~ assert id(self.plan_inverse.output_array) == id(self.data_in) == id(data_out) # DEBUG
         self.plan_inverse.update_arrays(self.refs["data_out"], self.refs["data_in"])
         return data_out
-
-

--- a/silx/math/fft/fftw.py
+++ b/silx/math/fft/fftw.py
@@ -136,9 +136,6 @@ class FFTW(BaseFFT):
         if self.check_alignment and not(pyfftw.is_byte_aligned(array)):
             # If the array is not properly aligned,
             # create a temp. array copy it to self.data_in or self.data_out
-            # ~ array2 = pyfftw.zeros_aligned(shape, dtype=dtype)
-            # ~ np.copyto(array2, array)
-            # ~ np.copyto(self_array, array)
             self_array[:] = array[:]
             arr_to_use = self_array
         else:
@@ -191,11 +188,8 @@ class FFTW(BaseFFT):
         self.plan_forward.update_arrays(data_in, data_out)
         # execute.__call__ does both update_arrays() and normalization
         self.plan_forward(
-            # ~ input_array=data_in,
-            # ~ output_array=data_out,
             ortho=self.fftw_norm_mode["ortho"],
         )
-        # ~ assert id(self.plan_forward.output_array) == id(self.data_out) == id(data_out) # DEBUG
         self.plan_forward.update_arrays(self.refs["data_in"], self.refs["data_out"])
         return data_out
 
@@ -213,11 +207,8 @@ class FFTW(BaseFFT):
         self.plan_inverse.update_arrays(data_in, data_out)
         # execute.__call__ does both update_arrays() and normalization
         self.plan_inverse(
-            # ~ input_array=data_in,
-            # ~ output_array=data_out,
             ortho=self.fftw_norm_mode["ortho"],
             normalise_idft=self.fftw_norm_mode["normalize"]
         )
-        # ~ assert id(self.plan_inverse.output_array) == id(self.data_in) == id(data_out) # DEBUG
         self.plan_inverse.update_arrays(self.refs["data_out"], self.refs["data_in"])
         return data_out

--- a/silx/math/fft/fftw.py
+++ b/silx/math/fft/fftw.py
@@ -120,8 +120,16 @@ class FFTW(BaseFFT):
 
     def set_data(self, self_array, array, shape, dtype, copy=True, name=None):
         """
-        self_array is an array owned by the current instance
-        (either self.data_in or self.data_out).
+        :param self_array: array owned by the current instance
+                           (either self.data_in or self.data_out).
+        :type: numpy.ndarray
+        :param self_array: data to set
+        :type: numpy.ndarray
+        :type tuple shape: shape of the array
+        :param dtype: type of the array
+        :type: numpy.dtype
+        :param bool copy: should we copy the array
+        :param str name: name of the array
 
         Copies are avoided when possible.
         """


### PR DESCRIPTION
- due to modifications there is incoherence between signature BaseFFT.set_data and FFTW.set_data, BaseFFT.fft and FFTW.fft, same for ifft
- I removed the DEBUG lines but you can skip the specific commit if those are mandatory.
- BaseFFT functions should be documented and FFTW functions documentation can be defined using the @docstring decorator